### PR TITLE
Have soss-genmsg find its transitive dependency on soss-core

### DIFF
--- a/packages/genmsg/soss-genmsgConfig.cmake
+++ b/packages/genmsg/soss-genmsgConfig.cmake
@@ -8,6 +8,9 @@ if(soss-genmsg_CONFIG_INCLUDED)
 endif()
 set(soss-genmsg_CONFIG_INCLUDED TRUE)
 
+include(CMakeFindDependencyMacro)
+find_dependency(soss-core REQUIRED)
+
 set(SOSS_GENMSG_GENERATE_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/scripts/soss_genmsg_generate.py")
 set(SOSS_GENMSG_FIND_PACKAGE_INFO_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/scripts/soss_genmsg_find_package_info.py")
 


### PR DESCRIPTION
This allows downstream users who want to generate message plugins to use

```
find_package(soss-genmsg)
```

instead of

```
find_package(soss-core)
find_package(soss-genmsg)
```