### PR TITLE
Enable soss-ros1 configuration to specify custom names for nodes

### DIFF
--- a/packages/ros1-test/resources/ros1__geometry_msgs.yaml
+++ b/packages/ros1-test/resources/ros1__geometry_msgs.yaml
@@ -1,5 +1,5 @@
 systems:
-  ros1: { type: ros1 }
+  ros1: { type: ros1, node_name: geometry_forwarder }
   mock: { type: mock }
 
 routes:

--- a/packages/ros1/src/SystemHandle.cpp
+++ b/packages/ros1/src/SystemHandle.cpp
@@ -59,13 +59,17 @@ void print_missing_mix_file(
 //==============================================================================
 bool SystemHandle::configure(
     const RequiredTypes& types,
-    const YAML::Node& /*configuration*/)
+    const YAML::Node& configuration)
 {
   int argc = 1;
   char* argv[1];
   char buffer[5] = "soss";
   argv[0] = buffer;
-  ros::init(argc, argv, std::string("soss_ros1"));
+
+  const YAML::Node yaml_node_name = configuration["node_name"];
+  std::string node_name = yaml_node_name?
+        yaml_node_name.as<std::string>() : std::string("soss_ros1");
+  ros::init(argc, argv, std::move(node_name));
 
   _node = std::make_unique<ros::NodeHandle>();
 


### PR DESCRIPTION
Every soss executable that wants to talk to ROS1 needs its own node name, so using a simple default node name for all instances is not a viable strategy.

This PR allows users to specify a node name for their ROS1 node from the soss config file.