### PR TITLE
Added latching and queue_size configuration

### DIFF
--- a/examples/hello_ros.yaml
+++ b/examples/hello_ros.yaml
@@ -8,5 +8,4 @@ routes:
 
 topics:
   hello_ros2: { type: "std_msgs/String", route: ros1_to_ros2 }
-  hello_ros1: { type: "std_msgs/String", route: ros2_to_ros1 }
-
+  hello_ros1: { type: "std_msgs/String", route: ros2_to_ros1, ros1 : { queue_size: 10, latch: false } }

--- a/packages/ros1/src/SystemHandle.cpp
+++ b/packages/ros1/src/SystemHandle.cpp
@@ -156,8 +156,7 @@ bool SystemHandle::subscribe(
     SubscriptionCallback callback,
     const YAML::Node& configuration)
 {
-  const YAML::Node& queue_config = configuration["queue_size"];
-  int queue_size = queue_config ? queue_config.as<int>() : default_queue_size;
+  int queue_size = configuration["queue_size"].as<int>(default_queue_size);
   // TODO(MXG): Parse configuration so users can change transport hints
   auto subscription = Factory::instance().create_subscription(
         message_type, *_node, topic_name,
@@ -176,11 +175,8 @@ std::shared_ptr<TopicPublisher> SystemHandle::advertise(
     const std::string& message_type,
     const YAML::Node& configuration)
 {
-  const YAML::Node& queue_config = configuration["queue_size"];
-  const YAML::Node& latch_config = configuration["latch"];
-
-  int queue_size = queue_config ? queue_config.as<int>() : default_queue_size;
-  bool latch_behavior = latch_config ? latch_config.as<bool>() : default_latch_behavior;
+  int queue_size = configuration["queue_size"].as<int>(default_queue_size);
+  bool latch_behavior = configuration["latch"].as<bool>(default_latch_behavior);
 
   if(topic_name.find('{') != std::string::npos)
   {


### PR DESCRIPTION
Add configurability of queue_size (publishers and subscribers) and latching behavior (publishers only).

Still missing TransportHints on subscriber side, currently thinking if (and how) to implement them without too much code bloat, since we need to call a different function depending on each hint and many of them are redundant (i.e. tcp = reliable, udp = unreliable).

Depends on https://github.com/osrf/soss/pull/27