### PR TITLE
Add support for ROS noetic (python3)

### DIFF
--- a/packages/genmsg/cmake/soss_genmsg_mix.cmake
+++ b/packages/genmsg/cmake/soss_genmsg_mix.cmake
@@ -70,7 +70,7 @@ function(soss_genmsg_mix)
   soss_mix_generator(
     IDL_TYPE genmsg
     SCRIPT
-      INTERPRETER python2
+      INTERPRETER "python$ENV{ROS_PYTHON_VERSION}"
       FIND ${SOSS_GENMSG_FIND_PACKAGE_INFO_SCRIPT}
       GENERATE ${SOSS_GENMSG_GENERATE_SCRIPT}
     PACKAGES ${_ARG_PACKAGES}

--- a/packages/genmsg/scripts/soss_genmsg_generate.py
+++ b/packages/genmsg/scripts/soss_genmsg_generate.py
@@ -13,9 +13,13 @@ except ImportError:
 import argparse
 import copy
 import em
-from io import BytesIO
 import os
 import sys
+
+if sys.version_info[0] > 2:
+    from io import StringIO as BufferIO
+else:
+    from io import BytesIO as BufferIO
 
 
 g_msg_context = MsgContext()
@@ -76,7 +80,7 @@ def generate_file(template, destination, context):
     filename = '.'.join(base_name_components)
     output_file_path = '/'.join([destination, filename])
 
-    output_buffer = BytesIO()
+    output_buffer = BufferIO()
     interpreter = em.Interpreter(output=output_buffer, globals=copy.deepcopy(context))
     interpreter.file(open(template, 'r'))
 


### PR DESCRIPTION
closes #12 

* select `INTERPRETER` based on `ROS_PYTHON_VERSION` (with fallback to just "python", if not set)
* use ~~StringIO~~BufferIO instead BytesIO

~~Not sure, if the latter fix works properly with Python2 in all cases.~~
It does not. BufferIO is either BytesIO (Python 2) or StringIO (Python 3)